### PR TITLE
Add sender filter to get posts

### DIFF
--- a/requests.http
+++ b/requests.http
@@ -16,3 +16,8 @@ GET http://localhost:3000/posts
 
 # Get a single post by ID
 GET http://localhost:3000/posts/6738b7b2944556561a86110a
+
+###
+
+# Get posts by sender
+GET http://localhost:3000/posts?sender=testuser@example.com

--- a/src/controllers/posts.js
+++ b/src/controllers/posts.js
@@ -5,8 +5,14 @@ export async function addPost(post) {
     return (await Post.create(post)).toJSON();
 }
 
-export async function getPosts() {
-    return (await Post.find()).map((post) => post.toJSON());
+export async function getPosts(filters) {
+    const query = {};
+
+    if (filters.sender) {
+        query.sender = filters.sender.toString();
+    }
+
+    return (await Post.find(query)).map((post) => post.toJSON());
 }
 
 export async function getPostById(id) {

--- a/src/routes/posts.js
+++ b/src/routes/posts.js
@@ -29,7 +29,8 @@ postRouter.post("/", async (req, res) => {
 
 postRouter.get("/", async (req, res) => {
     try {
-        const posts = await getPosts();
+        const { sender } = req.query;
+        const posts = await getPosts({ sender });
 
         return res.json(posts);
     } catch (err) {


### PR DESCRIPTION
Added an optional `?sender=<sender>` query param to `GET /posts` for filtering posts by sender