### PR TITLE
Refactor controllers

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
     "tabWidth": 4,
     "useTabs": false,
-    "printWidth": 120
+    "printWidth": 100
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
             "license": "ISC",
             "dependencies": {
                 "body-parser": "^1.20.3",
+                "celebrate": "^15.0.3",
                 "dotenv": "^16.4.5",
                 "express": "^5.0.1",
-                "express-joi-validation": "^6.0.0",
                 "joi": "^17.13.3",
                 "mongoose": "^8.8.1"
             },
@@ -249,6 +249,17 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/celebrate": {
+            "version": "15.0.3",
+            "resolved": "https://registry.npmjs.org/celebrate/-/celebrate-15.0.3.tgz",
+            "integrity": "sha512-ToF8ILq/F0KhQ0CPtexP7Cu9GkqKJ91VKy3ZOCV24aaNWdm3QCHqnXAKfKHrtcM2B2zmPFe11p8WWsQkmq8k4g==",
+            "license": "MIT",
+            "dependencies": {
+                "escape-html": "1.0.3",
+                "joi": "17.x.x",
+                "lodash": "4.17.x"
+            }
+        },
         "node_modules/chokidar": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -475,18 +486,6 @@
             },
             "engines": {
                 "node": ">= 18"
-            }
-        },
-        "node_modules/express-joi-validation": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/express-joi-validation/-/express-joi-validation-6.0.0.tgz",
-            "integrity": "sha512-n0ViD0F+x0XFFvlTgfCkYCkfQcqL1Xy/TXKBAuAHeTAmuOaHyLGaNrapXo1BqiWQfmmuIuSYK93QNyuRyKI7AA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.0.0"
-            },
-            "peerDependencies": {
-                "joi": "17"
             }
         },
         "node_modules/express/node_modules/body-parser": {
@@ -947,6 +946,12 @@
             "engines": {
                 "node": ">=12.0.0"
             }
+        },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "license": "MIT"
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "body-parser": "^1.20.3",
                 "dotenv": "^16.4.5",
-                "express": "^4.21.1",
+                "express": "^5.0.1",
                 "express-joi-validation": "^6.0.0",
                 "joi": "^17.13.3",
                 "mongoose": "^8.8.1"
@@ -81,13 +81,34 @@
             }
         },
         "node_modules/accepts": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
             "license": "MIT",
             "dependencies": {
-                "mime-types": "~2.1.34",
-                "negotiator": "0.6.3"
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/accepts/node_modules/mime-db": {
+            "version": "1.53.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
+            "integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/accepts/node_modules/mime-types": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.0.tgz",
+            "integrity": "sha512-XqoSHeCGjVClAmoGFG3lVFqQFRIrTVw2OH3axRqAcfaw+gHWIfnASS92AV+Rl/mk0MupgZTRHQOjxY6YVnzK5w==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.53.0"
             },
             "engines": {
                 "node": ">= 0.6"
@@ -108,9 +129,9 @@
             }
         },
         "node_modules/array-flatten": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+            "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
             "license": "MIT"
         },
         "node_modules/balanced-match": {
@@ -199,24 +220,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/call-bind": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.0",
-                "es-define-property": "^1.0.0",
-                "get-intrinsic": "^1.2.4",
-                "set-function-length": "^1.2.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
@@ -231,13 +234,13 @@
             }
         },
         "node_modules/call-bound": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.2.tgz",
-            "integrity": "sha512-0lk0PHFe/uz0vl527fG9CgdE9WdafjDbCXvBbs+LUv000TVt2Jjhqbs4Jwm8gz070w8xXyEAxrPOMullsxXeGg==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+            "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.8",
-                "get-intrinsic": "^1.2.5"
+                "call-bind-apply-helpers": "^1.0.1",
+                "get-intrinsic": "^1.2.6"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -279,9 +282,9 @@
             "license": "MIT"
         },
         "node_modules/content-disposition": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-            "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+            "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "5.2.1"
@@ -309,10 +312,13 @@
             }
         },
         "node_modules/cookie-signature": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-            "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-            "license": "MIT"
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
         },
         "node_modules/debug": {
             "version": "2.6.9",
@@ -321,23 +327,6 @@
             "license": "MIT",
             "dependencies": {
                 "ms": "2.0.0"
-            }
-        },
-        "node_modules/define-data-property": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/depd": {
@@ -372,12 +361,12 @@
             }
         },
         "node_modules/dunder-proto": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.0.tgz",
-            "integrity": "sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
             "license": "MIT",
             "dependencies": {
-                "call-bind-apply-helpers": "^1.0.0",
+                "call-bind-apply-helpers": "^1.0.1",
                 "es-errors": "^1.3.0",
                 "gopd": "^1.2.0"
             },
@@ -446,49 +435,46 @@
             }
         },
         "node_modules/express": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-            "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.0.1.tgz",
+            "integrity": "sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==",
             "license": "MIT",
             "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.20.3",
-                "content-disposition": "0.5.4",
+                "accepts": "^2.0.0",
+                "body-parser": "^2.0.1",
+                "content-disposition": "^1.0.0",
                 "content-type": "~1.0.4",
                 "cookie": "0.7.1",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
+                "cookie-signature": "^1.2.1",
+                "debug": "4.3.6",
                 "depd": "2.0.0",
                 "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "finalhandler": "1.3.1",
-                "fresh": "0.5.2",
+                "finalhandler": "^2.0.0",
+                "fresh": "2.0.0",
                 "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.3",
+                "merge-descriptors": "^2.0.0",
                 "methods": "~1.1.2",
+                "mime-types": "^3.0.0",
                 "on-finished": "2.4.1",
+                "once": "1.4.0",
                 "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.12",
                 "proxy-addr": "~2.0.7",
                 "qs": "6.13.0",
                 "range-parser": "~1.2.1",
+                "router": "^2.0.0",
                 "safe-buffer": "5.2.1",
-                "send": "0.19.0",
-                "serve-static": "1.16.2",
+                "send": "^1.1.0",
+                "serve-static": "^2.1.0",
                 "setprototypeof": "1.2.0",
                 "statuses": "2.0.1",
-                "type-is": "~1.6.18",
+                "type-is": "^2.0.0",
                 "utils-merge": "1.0.1",
                 "vary": "~1.1.2"
             },
             "engines": {
-                "node": ">= 0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
+                "node": ">= 18"
             }
         },
         "node_modules/express-joi-validation": {
@@ -501,6 +487,176 @@
             },
             "peerDependencies": {
                 "joi": "17"
+            }
+        },
+        "node_modules/express/node_modules/body-parser": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.0.2.tgz",
+            "integrity": "sha512-SNMk0OONlQ01uk8EPeiBvTW7W4ovpL5b1O3t1sjpPgfxOQ6BqQJ6XjxinDPR79Z6HdcD5zBBwr5ssiTlgdNztQ==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "content-type": "~1.0.5",
+                "debug": "3.1.0",
+                "destroy": "1.2.0",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.5.2",
+                "on-finished": "2.4.1",
+                "qs": "6.13.0",
+                "raw-body": "^3.0.0",
+                "type-is": "~1.6.18"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/express/node_modules/body-parser/node_modules/debug": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/express/node_modules/body-parser/node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express/node_modules/body-parser/node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express/node_modules/body-parser/node_modules/type-is": {
+            "version": "1.6.18",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+            "license": "MIT",
+            "dependencies": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.24"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express/node_modules/debug": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+            "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/express/node_modules/debug/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "license": "MIT"
+        },
+        "node_modules/express/node_modules/iconv-lite": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
+            "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/express/node_modules/mime-db": {
+            "version": "1.53.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
+            "integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express/node_modules/mime-types": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.0.tgz",
+            "integrity": "sha512-XqoSHeCGjVClAmoGFG3lVFqQFRIrTVw2OH3axRqAcfaw+gHWIfnASS92AV+Rl/mk0MupgZTRHQOjxY6YVnzK5w==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.53.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express/node_modules/raw-body": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+            "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.6.3",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/express/node_modules/raw-body/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/express/node_modules/type-is": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.0.tgz",
+            "integrity": "sha512-gd0sGezQYCbWSbkZr75mln4YBidWUN60+devscpLF5mtRDUpiaTvKpBNrdaCvel1NdR2k6vclXybU5fBd2i+nw==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^1.0.5",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express/node_modules/type-is/node_modules/media-typer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/fill-range": {
@@ -517,19 +673,28 @@
             }
         },
         "node_modules/finalhandler": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-            "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.0.0.tgz",
+            "integrity": "sha512-MX6Zo2adDViYh+GcxxB1dpO43eypOGUOL12rLCOTMQv/DfIbpSJUy4oQIIZhVZkH9e+bZWKMon0XHFEju16tkQ==",
             "license": "MIT",
             "dependencies": {
                 "debug": "2.6.9",
-                "encodeurl": "~2.0.0",
+                "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
                 "statuses": "2.0.1",
                 "unpipe": "~1.0.0"
             },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/finalhandler/node_modules/encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -544,12 +709,12 @@
             }
         },
         "node_modules/fresh": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
             "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.8"
             }
         },
         "node_modules/fsevents": {
@@ -633,18 +798,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/has-property-descriptors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-symbols": {
@@ -767,6 +920,12 @@
                 "node": ">=0.12.0"
             }
         },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "license": "MIT"
+        },
         "node_modules/joi": {
             "version": "17.13.3",
             "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
@@ -790,9 +949,9 @@
             }
         },
         "node_modules/math-intrinsics": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.0.0.tgz",
-            "integrity": "sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -814,10 +973,13 @@
             "license": "MIT"
         },
         "node_modules/merge-descriptors": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
             "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
@@ -829,18 +991,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-            "license": "MIT",
-            "bin": {
-                "mime": "cli.js"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/mime-db": {
@@ -934,9 +1084,9 @@
             }
         },
         "node_modules/mongoose": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.9.0.tgz",
-            "integrity": "sha512-b58zY3PLNBcoz6ZXFckr0leJcVVBMAOBvD+7Bj2ZjghAwntXmNnqwlDixTKQU3UYoQIGTv+AQx/0ThsvaeVrCA==",
+            "version": "8.9.2",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.9.2.tgz",
+            "integrity": "sha512-mLWynmZS1v8HTeMxyLhskQncS1SkrjW1eLNuFDYGQMQ/5QrFrxTLNwWXeCRZeKT2lXyaxW8bnJC9AKPT9jYMkw==",
             "license": "MIT",
             "dependencies": {
                 "bson": "^6.10.1",
@@ -1012,9 +1162,9 @@
             "license": "MIT"
         },
         "node_modules/negotiator": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -1108,6 +1258,15 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
         "node_modules/parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1118,10 +1277,13 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-            "license": "MIT"
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+            "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            }
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -1217,6 +1379,24 @@
                 "node": ">=8.10.0"
             }
         },
+        "node_modules/router": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.0.0.tgz",
+            "integrity": "sha512-dIM5zVoG8xhC6rnSN8uoAgFARwTE7BQs8YwHEvK0VCmfxQXMaOuA1uiR1IPwsW7JyK5iTt7Od/TC9StasS2NPQ==",
+            "license": "MIT",
+            "dependencies": {
+                "array-flatten": "3.0.0",
+                "is-promise": "4.0.0",
+                "methods": "~1.1.2",
+                "parseurl": "~1.3.3",
+                "path-to-regexp": "^8.0.0",
+                "setprototypeof": "1.2.0",
+                "utils-merge": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1257,36 +1437,52 @@
             }
         },
         "node_modules/send": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.1.0.tgz",
+            "integrity": "sha512-v67WcEouB5GxbTWL/4NeToqcZiAWEq90N888fczVArY8A79J0L4FD7vj5hm3eUMua5EpoQ59wa/oovY6TLvRUA==",
             "license": "MIT",
             "dependencies": {
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "mime": "1.6.0",
-                "ms": "2.1.3",
-                "on-finished": "2.4.1",
-                "range-parser": "~1.2.1",
-                "statuses": "2.0.1"
+                "debug": "^4.3.5",
+                "destroy": "^1.2.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^0.5.2",
+                "http-errors": "^2.0.0",
+                "mime-types": "^2.1.35",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.1"
             },
             "engines": {
-                "node": ">= 0.8.0"
+                "node": ">= 18"
             }
         },
-        "node_modules/send/node_modules/encodeurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+        "node_modules/send/node_modules/debug": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/send/node_modules/fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
             "license": "MIT",
             "engines": {
-                "node": ">= 0.8"
+                "node": ">= 0.6"
             }
         },
         "node_modules/send/node_modules/ms": {
@@ -1296,35 +1492,18 @@
             "license": "MIT"
         },
         "node_modules/serve-static": {
-            "version": "1.16.2",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.1.0.tgz",
+            "integrity": "sha512-A3We5UfEjG8Z7VkDv6uItWw6HY2bBSBJT1KtVESn6EOoOr2jAxNhxWCLY3jDE2WcuHXByWju74ck3ZgLwL8xmA==",
             "license": "MIT",
             "dependencies": {
-                "encodeurl": "~2.0.0",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.3",
-                "send": "0.19.0"
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.0.0"
             },
             "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/set-function-length": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-            "license": "MIT",
-            "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.4",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
+                "node": ">= 18"
             }
         },
         "node_modules/setprototypeof": {
@@ -1567,6 +1746,12 @@
             "engines": {
                 "node": ">=16"
             }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "license": "ISC"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "body-parser": "^1.20.3",
         "dotenv": "^16.4.5",
-        "express": "^4.21.1",
+        "express": "^5.0.1",
         "express-joi-validation": "^6.0.0",
         "joi": "^17.13.3",
         "mongoose": "^8.8.1"

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "description": "",
     "dependencies": {
         "body-parser": "^1.20.3",
+        "celebrate": "^15.0.3",
         "dotenv": "^16.4.5",
         "express": "^5.0.1",
-        "express-joi-validation": "^6.0.0",
         "joi": "^17.13.3",
         "mongoose": "^8.8.1"
     },

--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,7 @@ import express from "express";
 import bodyParser from "body-parser";
 import postRouter from "./routes/posts.js";
 import commentRouter from "./routes/comments.js";
-
+import { errors } from "celebrate";
 
 export function createApp() {
     const app = express();
@@ -10,6 +10,7 @@ export function createApp() {
     app.use(bodyParser.json());
     app.use("/posts", postRouter);
     app.use("/comments", commentRouter);
+    app.use(errors());
 
     return app;
 }

--- a/src/controllers/base-controller.js
+++ b/src/controllers/base-controller.js
@@ -1,0 +1,40 @@
+export default class BaseController {
+    constructor(model) {
+        this.model = model;
+    }
+
+    async create(req, res) {
+        const item = await this.model.create(req.body);
+
+        res.status(201).json(item);
+    }
+
+    async getItems(req, res) {
+        const items = await this.model.find(req.query);
+
+        res.json(items);
+    }
+
+    async getItemById(req, res) {
+        const item = await this.model.findById(req.params.id);
+
+        if (!item) {
+            res.status(404).json({ error: "Item not found" });
+        } else {
+            res.json(item);
+        }
+    }
+
+    async updateItemById(req, res) {
+        // Use updateOne method instead of findById and save
+        const item = await this.model.findById(req.params.id);
+
+        if (!item) {
+            res.status(404).json({ error: "Item not found" });
+        } else {
+            item.message = req.body.message;
+            item.save();
+            res.json(item);
+        }
+    }
+}

--- a/src/controllers/base-controller.js
+++ b/src/controllers/base-controller.js
@@ -26,7 +26,6 @@ export default class BaseController {
     }
 
     async updateItemById(req, res) {
-        // Use updateOne method instead of findById and save
         const item = await this.model.findById(req.params.id);
 
         if (!item) {
@@ -35,6 +34,16 @@ export default class BaseController {
             item.message = req.body.message;
             item.save();
             res.json(item);
+        }
+    }
+
+    async deleteItemById(req, res) {
+        const item = await this.model.findByIdAndDelete(req.params.id);
+
+        if (!item) {
+            res.status(404).json({ error: "Item not found" });
+        } else {
+            res.status(204).send();
         }
     }
 }

--- a/src/controllers/comments.js
+++ b/src/controllers/comments.js
@@ -1,23 +1,13 @@
 import Comment from "../models/comment.js";
-import { getPostById } from "./posts.js";
 
 export async function addComment(req, res) {
-    const comment = req.body;
-
-    const post = await getPostById(comment.post);
-
-    if (!post) {
-        res.status(404).json({ error: "Post does not exist" });
-    } else {
-        const newComment = await Comment.create(comment);
-        res.status(201).json(newComment);
-    }
+    const comment = await Comment.create(req.body);
+    res.status(201).json(comment);
 }
 
 export async function getComments(req, res) {
     const comments = await Comment.find(req.query);
-
-    return res.json(comments);
+    res.json(comments);
 }
 
 export async function getCommentById(req, res) {

--- a/src/controllers/comments.js
+++ b/src/controllers/comments.js
@@ -1,45 +1,8 @@
 import Comment from "../models/comment.js";
+import BaseController from "./base-controller.js";
 
-export async function addComment(req, res) {
-    const comment = await Comment.create(req.body);
-    res.status(201).json(comment);
-}
-
-export async function getComments(req, res) {
-    const comments = await Comment.find(req.query);
-    res.json(comments);
-}
-
-export async function getCommentById(req, res) {
-    const comment = await Comment.findById(req.params.id);
-
-    if (!comment) {
-        res.status(404).json({ error: "Comment not found" });
-    } else {
-        res.json(comment);
-    }
-}
-
-export async function updateCommentById(req, res) {
-    const comment = await Comment.findById(req.params.id);
-
-    if (!comment) {
-        res.status(404).json({ error: "Comment not found" });
-    } else {
-        comment.message = req.body.message;
-        await comment.save();
-
-        res.json(comment);
-    }
-}
-
-export async function deleteCommentById(req, res) {
-    const { id } = req.params;
-    const comment = await Comment.findByIdAndDelete(id);
-
-    if (!comment) {
-        res.status(404).json({ error: "Comment not found" });
-    } else {
-        res.status(204).send();
+export default class CommentsController extends BaseController {
+    constructor() {
+        super(Comment);
     }
 }

--- a/src/controllers/posts.js
+++ b/src/controllers/posts.js
@@ -1,35 +1,35 @@
-import mongoose from "mongoose";
 import Post from "../models/post.js";
 
-export async function addPost(post) {
-    return await Post.create(post);
+export async function addPost(req, res) {
+    const post = await Post.create(req.body);
+
+    res.status(201).json(post);
 }
 
-export async function getPosts(filters) {
-    const query = {};
+export async function getPosts(req, res) {
+    const posts = await Post.find(req.query);
 
-    if (filters.sender) {
-        query.sender = filters.sender.toString();
+    res.json(posts);
+}
+
+export async function getPostById(req, res) {
+    const post = await Post.findById(req.params.id);
+
+    if (!post) {
+        res.status(404).json({ error: "Post not found" });
+    } else {
+        res.json(post);
     }
-
-    return await Post.find(query);
 }
 
-export async function getPostById(id) {
-    if (!mongoose.Types.ObjectId.isValid(id)) {
-        return null;
-    }
+export async function updatePostById(req, res) {
+    const post = await Post.findById(req.params.id);
 
-    return await Post.findById(id);
-}
-
-export async function updatePostById(id, { message }) {
-    const post = await getPostById(id);
-
-    if (post) {
-        post.message = message;
+    if (!post) {
+        res.status(404).json({ error: "Post not found" });
+    } else {
+        post.message = req.body.message;
         post.save();
+        res.json(post);
     }
-
-    return post;
 }

--- a/src/controllers/posts.js
+++ b/src/controllers/posts.js
@@ -1,35 +1,8 @@
 import Post from "../models/post.js";
+import BaseController from "./base-controller.js";
 
-export async function addPost(req, res) {
-    const post = await Post.create(req.body);
-
-    res.status(201).json(post);
-}
-
-export async function getPosts(req, res) {
-    const posts = await Post.find(req.query);
-
-    res.json(posts);
-}
-
-export async function getPostById(req, res) {
-    const post = await Post.findById(req.params.id);
-
-    if (!post) {
-        res.status(404).json({ error: "Post not found" });
-    } else {
-        res.json(post);
-    }
-}
-
-export async function updatePostById(req, res) {
-    const post = await Post.findById(req.params.id);
-
-    if (!post) {
-        res.status(404).json({ error: "Post not found" });
-    } else {
-        post.message = req.body.message;
-        post.save();
-        res.json(post);
+export default class PostsController extends BaseController {
+    constructor() {
+        super(Post);
     }
 }

--- a/src/models/comment.js
+++ b/src/models/comment.js
@@ -1,10 +1,19 @@
 import { Schema, model } from "mongoose";
+import Post from "./post.js";
 
 const commentSchema = new Schema({
-    post: { type: Schema.Types.ObjectId, ref: 'Post', required: true },
+    post: { type: Schema.Types.ObjectId, ref: "Post", required: true },
     sender: { type: String, required: true },
     message: { type: String, required: true },
-    createdAt: { type: Date, default: Date.now }
+    createdAt: { type: Date, default: Date.now },
+});
+
+commentSchema.pre("save", { isAsync: true }, async function () {
+    const post = await Post.findById(this.post);
+
+    if (!post) {
+        throw Object.assign(new Error("Post not found"), { status: 404 });
+    }
 });
 
 export default model("Comment", commentSchema);

--- a/src/models/comment.js
+++ b/src/models/comment.js
@@ -8,7 +8,7 @@ const commentSchema = new Schema({
     createdAt: { type: Date, default: Date.now },
 });
 
-commentSchema.pre("save", { isAsync: true }, async function () {
+commentSchema.pre("save", async function () {
     const post = await Post.findById(this.post);
 
     if (!post) {

--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -1,3 +1,4 @@
+import Joi from "joi";
 import { Router } from "express";
 import { createValidator } from "express-joi-validation";
 import {
@@ -7,98 +8,34 @@ import {
     updateCommentById,
     deleteCommentById,
 } from "../controllers/comments.js";
-import Joi from "joi";
+import { validObjectId } from "./utils.js";
 
 const commentRouter = new Router();
 const validator = createValidator();
 
 const newCommentSchema = Joi.object({
-    post: Joi.string().required(),
+    post: Joi.string().custom(validObjectId).required(),
     message: Joi.string().required(),
     sender: Joi.string().required(),
 });
-commentRouter.post("/", validator.body(newCommentSchema), async (req, res) => {
-    const { post, message, sender } = req.body;
-
-    try {
-        const newComment = await addComment({ post, sender, message });
-
-        return res.status(201).json(newComment);
-    } catch (err) {
-        console.error("Error in creating comment:", err);
-
-        if (err.message === "Post not found") {
-            return res.status(404).json({ error: "Post not found" });
-        }
-
-        return res.status(500).json({ error: "Failed to create comment" });
-    }
-});
-
 const getCommentsSchema = Joi.object({
-    post: Joi.string().optional(),
+    post: Joi.string().custom(validObjectId).optional(),
     sender: Joi.string().optional(),
 });
-commentRouter.get("/", validator.query(getCommentsSchema), async (req, res) => {
-    try {
-        const { post, sender } = req.query;
-        const comments = await getComments({ post, sender });
-
-        return res.json(comments);
-    } catch (err) {
-        console.error("Error in fetching comments:", err);
-        return res.status(500).json({ error: "Failed to fetch comments" });
-    }
-});
-
-commentRouter.get("/:id", async (req, res) => {
-    try {
-        const comment = await getCommentById(req.params.id);
-
-        if (!comment) {
-            return res.status(404).json({ error: "Comment not found" });
-        }
-
-        return res.json(comment);
-    } catch (err) {
-        console.error("Error in fetching comment:", err);
-        return res.status(500).json({ error: "Failed to fetch comment" });
-    }
-});
-
 const updateCommentSchema = Joi.object({
     message: Joi.string().required(),
 });
-commentRouter.put("/:id", validator.body(updateCommentSchema), async (req, res) => {
-    const { message } = req.body;
+const idParamSchema = Joi.object({ id: Joi.string().required().custom(validObjectId) });
 
-    try {
-        const comment = await updateCommentById(req.params.id, { message });
-
-        if (!comment) {
-            return res.status(404).json({ error: "Comment not found" });
-        }
-
-        return res.json(comment);
-    } catch (err) {
-        console.error("Error in updating comment:", err);
-        return res.status(500).json({ error: "Failed to update comment" });
-    }
-});
-
-commentRouter.delete("/:id", async (req, res) => {
-    try {
-        const comment = await deleteCommentById(req.params.id);
-
-        if (!comment) {
-            return res.status(404).json({ error: "Comment not found" });
-        }
-
-        return res.status(204).send();
-    } catch (err) {
-        console.error("Error in deleting comment:", err);
-        return res.status(500).json({ error: "Failed to delete comment" });
-    }
-});
+commentRouter
+    .route("/")
+    .post(validator.body(newCommentSchema), addComment)
+    .get(validator.query(getCommentsSchema), getComments);
+commentRouter
+    .route("/:id")
+    .all(validator.params(idParamSchema))
+    .get(getCommentById)
+    .put(validator.body(updateCommentSchema), updateCommentById)
+    .delete(deleteCommentById);
 
 export default commentRouter;

--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -1,6 +1,6 @@
 import Joi from "joi";
 import { Router } from "express";
-import { createValidator } from "express-joi-validation";
+import { celebrate, Segments } from "celebrate";
 import {
     addComment,
     getComments,
@@ -11,30 +11,35 @@ import {
 import { idParamSchema, validObjectId } from "./utils.js";
 
 const commentRouter = new Router();
-const validator = createValidator();
 
-const newCommentSchema = Joi.object({
-    post: Joi.string().custom(validObjectId).required(),
-    message: Joi.string().required(),
-    sender: Joi.string().required(),
-});
-const getCommentsSchema = Joi.object({
-    post: Joi.string().custom(validObjectId).optional(),
-    sender: Joi.string().optional(),
-});
-const updateCommentSchema = Joi.object({
-    message: Joi.string().required(),
-});
+const newCommentSchema = {
+    [Segments.BODY]: Joi.object({
+        post: Joi.string().custom(validObjectId).required(),
+        message: Joi.string().required(),
+        sender: Joi.string().required(),
+    }),
+};
+const getCommentsSchema = {
+    [Segments.QUERY]: Joi.object({
+        post: Joi.string().custom(validObjectId).optional(),
+        sender: Joi.string().optional(),
+    }),
+};
+const updateCommentSchema = {
+    [Segments.BODY]: Joi.object({
+        message: Joi.string().required(),
+    }),
+};
 
 commentRouter
     .route("/")
-    .post(validator.body(newCommentSchema), addComment)
-    .get(validator.query(getCommentsSchema), getComments);
+    .post(celebrate(newCommentSchema), addComment)
+    .get(celebrate(getCommentsSchema), getComments);
 commentRouter
     .route("/:id")
-    .all(validator.params(idParamSchema))
+    .all(celebrate(idParamSchema))
     .get(getCommentById)
-    .put(validator.body(updateCommentSchema), updateCommentById)
+    .put(celebrate(updateCommentSchema), updateCommentById)
     .delete(deleteCommentById);
 
 export default commentRouter;

--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -1,16 +1,11 @@
 import Joi from "joi";
+import CommentsController from "../controllers/comments.js";
 import { Router } from "express";
 import { celebrate, Segments } from "celebrate";
-import {
-    addComment,
-    getComments,
-    getCommentById,
-    updateCommentById,
-    deleteCommentById,
-} from "../controllers/comments.js";
 import { idParamSchema, validObjectId } from "./utils.js";
 
 const commentRouter = new Router();
+const controller = new CommentsController();
 
 const newCommentSchema = {
     [Segments.BODY]: Joi.object({
@@ -33,13 +28,13 @@ const updateCommentSchema = {
 
 commentRouter
     .route("/")
-    .post(celebrate(newCommentSchema), addComment)
-    .get(celebrate(getCommentsSchema), getComments);
+    .get(celebrate(getCommentsSchema), controller.getItems.bind(controller))
+    .post(celebrate(newCommentSchema), controller.create.bind(controller));
 commentRouter
     .route("/:id")
     .all(celebrate(idParamSchema))
-    .get(getCommentById)
-    .put(celebrate(updateCommentSchema), updateCommentById)
-    .delete(deleteCommentById);
+    .get(controller.getItemById.bind(controller))
+    .put(celebrate(updateCommentSchema), controller.updateItemById.bind(controller))
+    .delete(controller.deleteItemById.bind(controller));
 
 export default commentRouter;

--- a/src/routes/comments.js
+++ b/src/routes/comments.js
@@ -8,7 +8,7 @@ import {
     updateCommentById,
     deleteCommentById,
 } from "../controllers/comments.js";
-import { validObjectId } from "./utils.js";
+import { idParamSchema, validObjectId } from "./utils.js";
 
 const commentRouter = new Router();
 const validator = createValidator();
@@ -25,7 +25,6 @@ const getCommentsSchema = Joi.object({
 const updateCommentSchema = Joi.object({
     message: Joi.string().required(),
 });
-const idParamSchema = Joi.object({ id: Joi.string().required().custom(validObjectId) });
 
 commentRouter
     .route("/")

--- a/src/routes/posts.js
+++ b/src/routes/posts.js
@@ -1,7 +1,8 @@
-import { Router } from "express";
-import { addPost, getPostById, getPosts, updatePostById } from "../controllers/posts.js";
-import { createValidator } from "express-joi-validation";
 import Joi from "joi";
+import { Router } from "express";
+import { createValidator } from "express-joi-validation";
+import { addPost, getPostById, getPosts, updatePostById } from "../controllers/posts.js";
+import { idParamSchema } from "./utils.js";
 
 const postRouter = new Router();
 const validator = createValidator();
@@ -10,65 +11,21 @@ const newPostSchema = Joi.object({
     message: Joi.string().required(),
     sender: Joi.string().required(),
 });
-postRouter.post("/", validator.body(newPostSchema), async (req, res) => {
-    const { message, sender } = req.body;
-
-    try {
-        const newPost = await addPost({ message, sender });
-
-        return res.status(201).json(newPost);
-    } catch (err) {
-        console.error("Error in creating post:", err);
-
-        return res.status(500).json({ error: "Failed to create post" });
-    }
-});
-
 const getPostsSchema = Joi.object({
     sender: Joi.string().optional(),
 });
-postRouter.get("/", validator.query(getPostsSchema), async (req, res) => {
-    try {
-        const { sender } = req.query;
-        const posts = await getPosts({ sender });
-
-        return res.json(posts);
-    } catch (err) {
-        console.error("Error in fetching posts:", err);
-
-        return res.status(500).json({ error: "Failed to fetch posts" });
-    }
-});
-
-postRouter.get("/:id", async (req, res) => {
-    const post = await getPostById(req.params.id);
-
-    if (!post) {
-        return res.status(404).json({ error: "Post not found" });
-    }
-
-    return res.json(post);
-});
-
 const updatePostSchema = Joi.object({
     message: Joi.string().required(),
 });
-postRouter.put("/:id", validator.body(updatePostSchema), async (req, res) => {
-    const { message } = req.body;
 
-    try {
-        const post = await updatePostById(req.params.id, { message });
-
-        if (!post) {
-            return res.status(404).json({ error: "Post not found" });
-        }
-
-        return res.json(post);
-    } catch (err) {
-        console.error("Error in updating post:", err);
-
-        return res.status(500).json({ error: "Failed to update post" });
-    }
-});
+postRouter
+    .route("/")
+    .post(validator.body(newPostSchema), addPost)
+    .get(validator.query(getPostsSchema), getPosts);
+postRouter
+    .route("/:id")
+    .all(validator.params(idParamSchema))
+    .get(getPostById)
+    .put(validator.body(updatePostSchema), updatePostById);
 
 export default postRouter;

--- a/src/routes/posts.js
+++ b/src/routes/posts.js
@@ -1,10 +1,11 @@
 import Joi from "joi";
+import PostsController from "../controllers/posts.js";
 import { Router } from "express";
 import { celebrate, Segments } from "celebrate";
-import { addPost, getPostById, getPosts, updatePostById } from "../controllers/posts.js";
 import { idParamSchema } from "./utils.js";
 
 const postRouter = new Router();
+const controller = new PostsController();
 
 const newPostSchema = {
     [Segments.BODY]: Joi.object({
@@ -15,22 +16,22 @@ const newPostSchema = {
 const getPostsSchema = {
     [Segments.QUERY]: Joi.object({
         sender: Joi.string().optional(),
-    })
+    }),
 };
 const updatePostSchema = {
     [Segments.BODY]: Joi.object({
         message: Joi.string().required(),
-    })
+    }),
 };
 
 postRouter
     .route("/")
-    .post(celebrate(newPostSchema), addPost)
-    .get(celebrate(getPostsSchema), getPosts);
+    .get(celebrate(getPostsSchema), controller.getItems.bind(controller))
+    .post(celebrate(newPostSchema), controller.create.bind(controller));
 postRouter
     .route("/:id")
     .all(celebrate(idParamSchema))
-    .get(getPostById)
-    .put(celebrate(updatePostSchema), updatePostById);
+    .get(controller.getItemById.bind(controller))
+    .put(celebrate(updatePostSchema), controller.updateItemById.bind(controller));
 
 export default postRouter;

--- a/src/routes/posts.js
+++ b/src/routes/posts.js
@@ -1,31 +1,36 @@
 import Joi from "joi";
 import { Router } from "express";
-import { createValidator } from "express-joi-validation";
+import { celebrate, Segments } from "celebrate";
 import { addPost, getPostById, getPosts, updatePostById } from "../controllers/posts.js";
 import { idParamSchema } from "./utils.js";
 
 const postRouter = new Router();
-const validator = createValidator();
 
-const newPostSchema = Joi.object({
-    message: Joi.string().required(),
-    sender: Joi.string().required(),
-});
-const getPostsSchema = Joi.object({
-    sender: Joi.string().optional(),
-});
-const updatePostSchema = Joi.object({
-    message: Joi.string().required(),
-});
+const newPostSchema = {
+    [Segments.BODY]: Joi.object({
+        message: Joi.string().required(),
+        sender: Joi.string().required(),
+    }),
+};
+const getPostsSchema = {
+    [Segments.QUERY]: Joi.object({
+        sender: Joi.string().optional(),
+    })
+};
+const updatePostSchema = {
+    [Segments.BODY]: Joi.object({
+        message: Joi.string().required(),
+    })
+};
 
 postRouter
     .route("/")
-    .post(validator.body(newPostSchema), addPost)
-    .get(validator.query(getPostsSchema), getPosts);
+    .post(celebrate(newPostSchema), addPost)
+    .get(celebrate(getPostsSchema), getPosts);
 postRouter
     .route("/:id")
-    .all(validator.params(idParamSchema))
+    .all(celebrate(idParamSchema))
     .get(getPostById)
-    .put(validator.body(updatePostSchema), updatePostById);
+    .put(celebrate(updatePostSchema), updatePostById);
 
 export default postRouter;

--- a/src/routes/utils.js
+++ b/src/routes/utils.js
@@ -1,0 +1,9 @@
+import mongoose from "mongoose";
+
+export function validObjectId(value, helpers) {
+    if (!mongoose.Types.ObjectId.isValid(value)) {
+        return helpers.message("Invalid post ID");
+    }
+
+    return value;
+}

--- a/src/routes/utils.js
+++ b/src/routes/utils.js
@@ -1,3 +1,4 @@
+import { Segments } from "celebrate";
 import Joi from "joi";
 import mongoose from "mongoose";
 
@@ -9,4 +10,6 @@ export function validObjectId(value, helpers) {
     return value;
 }
 
-export const idParamSchema = Joi.object({ id: Joi.string().required().custom(validObjectId) });
+export const idParamSchema = {
+    [Segments.PARAMS]: Joi.object({ id: Joi.string().required().custom(validObjectId) }),
+};

--- a/src/routes/utils.js
+++ b/src/routes/utils.js
@@ -1,3 +1,4 @@
+import Joi from "joi";
 import mongoose from "mongoose";
 
 export function validObjectId(value, helpers) {
@@ -7,3 +8,5 @@ export function validObjectId(value, helpers) {
 
     return value;
 }
+
+export const idParamSchema = Joi.object({ id: Joi.string().required().custom(validObjectId) });


### PR DESCRIPTION
* Extracted common controllers logic to `BaseController`
* Upgraded `express` to version 5 in order to [support error handling](https://expressjs.com/en/guide/error-handling.html#error-handling) for async routes
* Replaced `express-joi-validation` with `celebrate` since the former does not support `express` 5 (anyway, `celebrate` is more popular and more feature rich)